### PR TITLE
Add local [regex] pattern cache

### DIFF
--- a/PSStringScanner.psm1
+++ b/PSStringScanner.psm1
@@ -202,6 +202,7 @@ class PSStringScannerEx : PSStringScanner {
 }
 
 function New-PSStringScanner {
+    [OutputType([PSStringScanner])]
     param(
         [Parameter(Mandatory)]
         $text
@@ -211,6 +212,7 @@ function New-PSStringScanner {
 }
 
 function New-PSStringScannerEx {
+    [OutputType([PSStringScannerEx])]
     param(
         [Parameter(Mandatory)]
         $text


### PR DESCRIPTION
One of the annoying downsides of the non-static `Regex.Match(string input, int startAt)` method overload is that the framework assumes you'll re-use the `[regex]` instance and therefore it internally bypasses the static regex cache.

This commit fixes that by caching all new regex instances and indexing them by their exact pattern.

Next obvious addition to this would be a user-defined cap + LRU policy (could be achieved with a simple queue or just an ordered list as a recency index)