### PR TITLE
Add Type hints to New-PSStringScanner*

### DIFF
--- a/PSStringScanner.psm1
+++ b/PSStringScanner.psm1
@@ -202,6 +202,7 @@ class PSStringScannerEx : PSStringScanner {
 }
 
 function New-PSStringScanner {
+    [OutputType([PSStringScanner])]
     param(
         [Parameter(Mandatory)]
         $text
@@ -211,6 +212,7 @@ function New-PSStringScanner {
 }
 
 function New-PSStringScannerEx {
+    [OutputType([PSStringScannerEx])]
     param(
         [Parameter(Mandatory)]
         $text


### PR DESCRIPTION
Adding [OutputType([PSStringScanner*])] attributes to both cmdlets, type inference will allow for better autocompletion support